### PR TITLE
Allow diagrams to be Zoomed in on.

### DIFF
--- a/src/diagram_html_emitter.rs
+++ b/src/diagram_html_emitter.rs
@@ -1,15 +1,13 @@
-use chrono::{DateTime, Local, SecondsFormat};
-use std::fs;
 use super::diagram_text_emitter;
 use super::epic_info;
+use chrono::{DateTime, Local, SecondsFormat};
+use std::fs;
 
 fn format_labels(labels: &Option<Vec<epic_info::Label>>) -> String {
     let label_names = match labels {
         Some(labels) => labels
             .iter()
-            .map(|l| {
-                format!("<span>{}</span>", l.name)
-            })
+            .map(|l| format!("<span>{}</span>", l.name))
             .collect::<Vec<String>>()
             .join(", "),
         None => "".to_owned(),
@@ -42,53 +40,36 @@ fn prelude() -> String {
 }
 
 fn head() -> String {
+    let ui_script = fs::read_to_string("src/ui.js").unwrap();
     let css = fs::read_to_string("src/styles.css").unwrap();
-    return format!(r#"
+    return format!(
+        r#"
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
 
-    <script>
-        var currentNode = null;
-
-        function hideEmptyState() {{
-            let dom = document.getElementById("empty-state");
-            dom.className = "not-selected";
-        }}
-
-        function hideStory(storyId) {{
-            let dom = document.getElementById("story-details-" + storyId);
-            dom.className = "not-selected";
-        }}
-
-        function showStory(storyId) {{
-            let dom = document.getElementById("story-details-" + storyId);
-            dom.className = "selected";
-        }}
-
-        function ticketNodeCallback(storyId) {{
-            if (currentNode) {{
-                hideStory(currentNode);
-            }} else {{
-                hideEmptyState();
-            }}
-            showStory(storyId);
-            currentNode = storyId;
-        }}
-    </script>
-
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+    <script src="https://d3js.org/d3.v6.min.js"></script>
+
     <script>
       mermaid.initialize({{
-          startOnLoad: true,
-          securityLevel: 'loose',
+        startOnLoad: true,
+        securityLevel: 'loose',
       }});
     </script>
-  <style>
-      {}
-  </style>
+
+    <script>
+      {ui_script}
+    </script>
+
+    <style>
+      {css}
+    </style>
   </head>
-  "#, css);
+  "#,
+        css = css,
+        ui_script = ui_script,
+    );
 }
 
 fn postlude() -> String {

--- a/src/diagram_html_emitter.rs
+++ b/src/diagram_html_emitter.rs
@@ -54,7 +54,6 @@ fn head() -> String {
     <script>
       mermaid.initialize({{
         startOnLoad: true,
-        securityLevel: 'loose',
       }});
     </script>
 

--- a/src/diagram_text_emitter.rs
+++ b/src/diagram_text_emitter.rs
@@ -46,7 +46,8 @@ fn get_ticket_numbers_from_blocker_description(blocker_desc: &str) -> Vec<String
         static ref FULL_URL_REGEX: Regex =
             Regex::new(r"https://www.pivotaltracker.com/story/show/([0-9]+)").unwrap();
         static ref ALTERNATE_URL_REGEX: Regex =
-            Regex::new(r"https://www.pivotaltracker.com/n/projects/([0-9]+)/stories/([0-9]+)").unwrap();
+            Regex::new(r"https://www.pivotaltracker.com/n/projects/([0-9]+)/stories/([0-9]+)")
+                .unwrap();
     }
     let mut tickets: Vec<String> = Vec::new();
     let mut short_tag_ticket_ids = SHORT_TAG_REGEX
@@ -79,13 +80,6 @@ fn story_node(story: &epic_info::Story) -> String {
         &epic_info::StoryState::Unstarted => format!(":::{}", &GREY),
         &epic_info::StoryState::Unscheduled => format!(":::{}", &GREY),
     };
-    // Double quotes will prevent the file from parsing
-    // let safe_name = &story.name.replace("\"", "'");
-    // let link = format!(
-    //     "click {} \"{}\" \"{}\" _blank",
-    //     &story.id, &story.url, &safe_name
-    // );
-    let link = format!("click {} call ticketNodeCallback()", &story.id);
 
     let deps = match &story.blockers {
         Some(blockers) => blockers
@@ -113,12 +107,10 @@ fn story_node(story: &epic_info::Story) -> String {
     return format!(
         "\
             \t{node_id}{status}\n\
-            \t{link}\n\
             {deps}\
             \n",
         node_id = node_id,
         status = status,
-        link = link,
         deps = deps,
     );
 }

--- a/src/epic_info.rs
+++ b/src/epic_info.rs
@@ -54,9 +54,7 @@ pub struct Label {
     pub name: String,
 }
 
-async fn request_project(
-    path: String,
-) -> Result<reqwest::Response, Box<dyn std::error::Error>> {
+async fn request_project(path: String) -> Result<reqwest::Response, Box<dyn std::error::Error>> {
     let tracker_token = std::env::var("PIVOTAL_TRACKER_TOKEN").unwrap();
     let project_id = std::env::var("PROJECT_ID").unwrap();
     let response = reqwest::Client::new()
@@ -67,9 +65,7 @@ async fn request_project(
     return Ok(response);
 }
 
-pub async fn get_epics_with_label(
-    label: &str,
-) -> Result<Vec<Epic>, Box<dyn std::error::Error>> {
+pub async fn get_epics_with_label(label: &str) -> Result<Vec<Epic>, Box<dyn std::error::Error>> {
     let response = request_project(format!("/epics?filter={}", label)).await?;
     let epics: Vec<Epic> = response.json().await?;
     return Ok(epics);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
 
-use dotenv;
 use clap::{App, Arg};
+use dotenv;
 
 mod diagram_html_emitter;
 mod diagram_text_emitter;

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,7 +3,13 @@ body,
 main {
   height: 100%;
   font-size: 16px;
-  font-family: 'Open Sans', Arial, Helvetica, sans-serif;
+  font-family: "Open Sans", Arial, Helvetica, sans-serif;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }
 
 body {
@@ -11,9 +17,14 @@ body {
 }
 
 .wrapper {
+  display: flex;
+  flex-direction: column;
+
   background-color: white;
-  box-shadow: 1px 1px 5px 10px rgba(0,0,0,0.2);
+  box-shadow: 1px 1px 5px 10px rgba(0, 0, 0, 0.2);
   border-radius: 5px;
+
+  min-height: 80%;
 }
 
 nav {
@@ -33,12 +44,21 @@ footer {
 }
 
 .diagram-container {
+  display: flex;
   flex-grow: 1;
 }
+
 .panel {
   padding: 0.5rem;
   border-bottom: 1px solid #cbcad3;
   min-height: 125px;
+}
+
+.mermaid {
+  display: flex;
+}
+.mermaid svg {
+  height: 100%;
 }
 
 .not-selected {

--- a/src/styles.css
+++ b/src/styles.css
@@ -61,6 +61,10 @@ footer {
   height: 100%;
 }
 
+.mermaid svg .nodes .node {
+  cursor: pointer;
+}
+
 .not-selected {
   display: none;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -14,6 +14,7 @@ main {
 
 body {
   background-color: #212121;
+  margin: 0;
 }
 
 .wrapper {
@@ -24,7 +25,7 @@ body {
   box-shadow: 1px 1px 5px 10px rgba(0, 0, 0, 0.2);
   border-radius: 5px;
 
-  min-height: 80%;
+  min-height: 94%;
 }
 
 nav {
@@ -51,7 +52,7 @@ footer {
 .panel {
   padding: 0.5rem;
   border-bottom: 1px solid #cbcad3;
-  min-height: 125px;
+  min-height: 160px;
 }
 
 .mermaid {
@@ -63,6 +64,10 @@ footer {
 
 .mermaid svg .nodes .node {
   cursor: pointer;
+}
+
+.label-container#highlight-this-node {
+  filter: drop-shadow(0 0 8px #0ff);
 }
 
 .not-selected {

--- a/src/ui.js
+++ b/src/ui.js
@@ -33,10 +33,22 @@ window.addEventListener("load", function () {
     var inner = svg.select("g");
     var zoom = d3
       .zoom()
+      // .clickDistance(20)
+      .filter(function (event) {
+        console.log("event", event);
+        switch (event.type) {
+          case "mousedown":
+            return event.button === 1;
+          case "wheel":
+            return event.button === 0;
+          default:
+            return false;
+        }
+      })
+      .scaleExtent([1 / 2, 8])
       .on("zoom", function (event) {
         inner.attr("transform", event.transform);
-      })
-      .clickDistance(20);
+      });
     svg.call(zoom);
   });
 });

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,42 @@
+var currentNode = null;
+
+function hideEmptyState() {
+  let dom = document.getElementById("empty-state");
+  dom.className = "not-selected";
+}
+
+function hideStory(storyId) {
+  let dom = document.getElementById("story-details-" + storyId);
+  dom.className = "not-selected";
+}
+
+function showStory(storyId) {
+  let dom = document.getElementById("story-details-" + storyId);
+  dom.className = "selected";
+}
+
+function ticketNodeCallback(storyId) {
+  if (currentNode) {
+    hideStory(currentNode);
+  } else {
+    hideEmptyState();
+  }
+  showStory(storyId);
+  currentNode = storyId;
+}
+
+window.addEventListener("load", function () {
+  var svgs = d3.selectAll(".mermaid svg");
+  svgs.each(function () {
+    var svg = d3.select(this);
+    svg.html("<g>" + svg.html() + "</g>");
+    var inner = svg.select("g");
+    var zoom = d3
+      .zoom()
+      .on("zoom", function (event) {
+        inner.attr("transform", event.transform);
+      })
+      .clickDistance(20);
+    svg.call(zoom);
+  });
+});

--- a/src/ui.js
+++ b/src/ui.js
@@ -42,10 +42,6 @@ window.addEventListener("load", function () {
   svgs.each(function () {
     var svg = d3.select(this);
 
-    // TODO check if this is needed
-    // Wrap the element in an extra `g`
-    svg.html("<g>" + svg.html() + "</g>");
-
     // Bind new events
     // TODO add styling to the selected element
     // TODO make it clear that the nodes are clickable

--- a/src/ui.js
+++ b/src/ui.js
@@ -44,7 +44,6 @@ window.addEventListener("load", function () {
 
     // Bind new events
     // TODO add styling to the selected element
-    // TODO make it clear that the nodes are clickable
     svg.selectAll(".nodes").on("click", (e) => {
       let storyId;
       if (e.target.tagName === "rect") {

--- a/src/ui.js
+++ b/src/ui.js
@@ -5,6 +5,11 @@ function hideEmptyState() {
   dom.className = "not-selected";
 }
 
+function showEmptyState() {
+  let dom = document.getElementById("empty-state");
+  dom.className = "selected";
+}
+
 function hideStory(storyId) {
   let dom = document.getElementById("story-details-" + storyId);
   dom.className = "not-selected";
@@ -15,40 +20,52 @@ function showStory(storyId) {
   dom.className = "selected";
 }
 
-function ticketNodeCallback(storyId) {
+function ticketNodeClickedCallback(storyId) {
   if (currentNode) {
     hideStory(currentNode);
   } else {
     hideEmptyState();
   }
-  showStory(storyId);
-  currentNode = storyId;
+  if (currentNode !== storyId) {
+    // If selecting a new story show it
+    showStory(storyId);
+    currentNode = storyId;
+  } else {
+    // If the story is already selected de-select it.
+    showEmptyState();
+    currentNode = null;
+  }
 }
 
 window.addEventListener("load", function () {
   var svgs = d3.selectAll(".mermaid svg");
   svgs.each(function () {
     var svg = d3.select(this);
+
+    // TODO check if this is needed
+    // Wrap the element in an extra `g`
     svg.html("<g>" + svg.html() + "</g>");
+
+    // Bind new events
+    // TODO add styling to the selected element
+    // TODO make it clear that the nodes are clickable
+    svg.selectAll(".nodes").on("click", (e) => {
+      let storyId;
+      if (e.target.tagName === "rect") {
+        storyId = e.target.nextSibling.textContent;
+      } else {
+        storyId = e.target.textContent;
+      }
+      ticketNodeClickedCallback(storyId);
+    });
+
     var inner = svg.select("g");
     var zoom = d3
       .zoom()
-      // .clickDistance(20)
-      .filter(function (event) {
-        console.log("event", event);
-        switch (event.type) {
-          case "mousedown":
-            return event.button === 1;
-          case "wheel":
-            return event.button === 0;
-          default:
-            return false;
-        }
-      })
       .scaleExtent([1 / 2, 8])
       .on("zoom", function (event) {
         inner.attr("transform", event.transform);
       });
-    svg.call(zoom);
+    svg.call(zoom).on("dblclick.zoom", null);
   });
 });

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,4 +1,5 @@
-var currentNode = null;
+var currentStoryId = null;
+var currentNodeRectangle = null;
 
 function hideEmptyState() {
   let dom = document.getElementById("empty-state");
@@ -20,20 +21,35 @@ function showStory(storyId) {
   dom.className = "selected";
 }
 
-function ticketNodeClickedCallback(storyId) {
-  if (currentNode) {
-    hideStory(currentNode);
+function highlightSelectedNode(node) {
+  node.id = "highlight-this-node";
+}
+
+function unHighlightSelectedNode(node) {
+  node.id = "unhighlight-this-node";
+}
+
+function storyNodeClickedCallback(storyId, nodeRectangle) {
+  if (currentStoryId) {
+    hideStory(currentStoryId);
+    if (currentNodeRectangle) {
+      unHighlightSelectedNode(currentNodeRectangle);
+    }
   } else {
     hideEmptyState();
   }
-  if (currentNode !== storyId) {
+
+  if (currentStoryId !== storyId) {
     // If selecting a new story show it
     showStory(storyId);
-    currentNode = storyId;
+    highlightSelectedNode(nodeRectangle);
+    currentStoryId = storyId;
+    currentNodeRectangle = nodeRectangle;
   } else {
     // If the story is already selected de-select it.
     showEmptyState();
-    currentNode = null;
+    currentStoryId = null;
+    currentNodeRectangle = null;
   }
 }
 
@@ -42,16 +58,20 @@ window.addEventListener("load", function () {
   svgs.each(function () {
     var svg = d3.select(this);
 
-    // Bind new events
-    // TODO add styling to the selected element
+    // Bind click events to each of the story nodes. This will get the story id
+    // and the `rect` element within the `svg` this will then be used to select
+    // the story.
     svg.selectAll(".nodes").on("click", (e) => {
       let storyId;
+      let rectangle;
       if (e.target.tagName === "rect") {
+        rectangle = e.target;
         storyId = e.target.nextSibling.textContent;
       } else {
+        rectangle = e.target.parentNode.parentNode.parentNode.previousSibling;
         storyId = e.target.textContent;
       }
-      ticketNodeClickedCallback(storyId);
+      storyNodeClickedCallback(storyId, rectangle);
     });
 
     var inner = svg.select("g");


### PR DESCRIPTION
One of the things that I found was that some very large diagrams (or
even some medium ones) would not not look great and you would want to
zoom in on a subsection of them.

This PR allows that by using d3 zoom (a package which is a part of d3 and allows for zooming in using the wheel and pinching, etc). This package don't propagate the click events so this PR reworks how "selection" works. Mermaid no longer calls a callback on the click, instead we setup event handlers for click events on all of the `.nodes` elements.

This PR also starts to highlight what the selected node is.

The content fills up the full height of the screen.

This PR moves the JS scripts into their own file.  Previously after the
introduction of a `css` file being passed in and the block becoming a
"format macro template" the `{` and `}` needed to be escaped.

This PR also runs `cargo fmt` on a number of files (ideally this should also be checked in CI).


## Screenshots

### Before

![zoom-before](https://user-images.githubusercontent.com/607279/154997054-b9b5b8dd-7846-42c8-83e4-ab79c6524b8d.gif)


### After

![zoom-after](https://user-images.githubusercontent.com/607279/155021843-c2f34b5a-70a0-43db-bdc2-d95cf9c549e4.gif)
