### PR TITLE
Adds story label background colours.

### DIFF
--- a/src/diagram_html_emitter.rs
+++ b/src/diagram_html_emitter.rs
@@ -3,7 +3,7 @@ use super::epic_info;
 use chrono::{DateTime, Local, SecondsFormat};
 use std::fs;
 
-fn story_labels(story_labels: &Option<Vec<epic_info::Label>>, epic_label: &str) -> String {
+fn format_story_labels(story_labels: &Option<Vec<epic_info::Label>>, epic_label: &str) -> String {
     let epic_lowercase = epic_label.to_lowercase();
     let labels_html = match story_labels {
         Some(story_labels) => story_labels
@@ -24,7 +24,7 @@ fn story_labels(story_labels: &Option<Vec<epic_info::Label>>, epic_label: &str) 
 }
 
 fn story_details(story: &epic_info::Story, epic_name: &str) -> String {
-    let labels_html = story_labels(&story.labels, epic_name);
+    let labels_html = format_story_labels(&story.labels, epic_name);
     return format!(
         "\
             <div id='story-details-{story_id}' class='not-selected'>\

--- a/src/diagram_html_emitter.rs
+++ b/src/diagram_html_emitter.rs
@@ -28,10 +28,10 @@ fn story_details(story: &epic_info::Story, epic_name: &str) -> String {
     return format!(
         "\
             <div id='story-details-{story_id}' class='not-selected'>\
-                <p>id: <a href='{story_url}' target=_blank>{story_id}</a></p>\
-                <p>name: {name}</p>\
-                <p>labels: {labels}</p>\
-                <p>current state: {current_state:?}</p>\
+                <p><b>Id:</b> <a href='{story_url}' target=_blank>{story_id}</a></p>\
+                <p><b>Name:</b> {name}</p>\
+                <p><b>Labels:</b> {labels}</p>\
+                <p><b>Current State:</b> {current_state:?}</p>\
             </div>\
             \n",
         story_id = &story.id,

--- a/src/diagram_html_emitter.rs
+++ b/src/diagram_html_emitter.rs
@@ -17,7 +17,7 @@ fn story_labels(story_labels: &Option<Vec<epic_info::Label>>, epic_label: &str) 
 
     let mut story_labels_html = format!("<span class=\"badge-epic\">{}</span>", epic_lowercase);
     if labels_html.len() > 0 {
-        story_labels_html = vec![story_labels_html, labels_html].join(", ");
+        story_labels_html = format!("{}, {}", &story_labels_html, &labels_html);
     }
 
     return story_labels_html;

--- a/src/styles.css
+++ b/src/styles.css
@@ -76,3 +76,31 @@ footer {
 .selected {
   display: block;
 }
+
+.badge-epic {
+  display: inline-block;
+  padding: 0.35em 0.65em;
+  font-size: .75em;
+  font-weight: 700;
+  line-height: 1;
+  color: #fff;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: 0.25rem;
+  background-color: #7148b2;
+}
+
+.badge-label {
+  display: inline-block;
+  padding: 0.35em 0.65em;
+  font-size: .75em;
+  font-weight: 700;
+  line-height: 1;
+  color: #fff;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: 0.25rem;
+  background-color: #588a00;
+}


### PR DESCRIPTION
## Description
* Adds background style to labels + epics for stories.
* In fact, the css is a modified version of Bootstrap badge style.
* The code assumes the stories have only one epic and that pic is the _current_ epic.
   * Pivotal Tracker labels are all in lower case even if the epics or labels contain upper case.
   * The first badge will always be the current epic being drawn.

## For Reviewers
* It has been a very long time since I have done straight css.  I could not really get nested css to work.  Is there a better way?

## Screenshots
### Story that contains multiple labels
![Screen Shot 2022-03-07 at 1 36 52 AM](https://user-images.githubusercontent.com/11049883/156980625-f5060a41-ab7c-45b3-9c92-b30d610a8db4.png)

### Story that contains only the epic
![Screen Shot 2022-03-07 at 1 37 36 AM](https://user-images.githubusercontent.com/11049883/156980656-352ffeb7-a01c-4f2d-ac3b-26b05c86929a.png)
